### PR TITLE
bump version number so this runs on FF8.x

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -13,7 +13,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
         <em:minVersion>3.5</em:minVersion>
-        <em:maxVersion>8.0</em:maxVersion>
+        <em:maxVersion>8.9</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
I haven't tested Firepicker with FireFox 8, but I am bumping up the max version number from 8.0 to 8.9 so that it can be installed. 

I love Firepicker, and can't get my work done without it! :D
